### PR TITLE
Feature/20231201-2 - Update Constants, Validators, and Login / Register Implementation

### DIFF
--- a/docs/api.specifications/login.api.specifications.md
+++ b/docs/api.specifications/login.api.specifications.md
@@ -1,0 +1,93 @@
+# POST /api/v1/account/login
+
+## Request
+
+### Request with valid inputs
+<!-- markdownlint-disable -->
+```json
+// request headers
+{
+  "Content-Type": "application/json"
+}
+```
+```json
+// request body with valid email as login, and valid password
+{
+  "login": "username444@email.com",
+  "password": "Password123"
+}
+```
+OR
+```json
+// request body with valid username as login, and valid password
+{
+  "login": "username444",
+  "password": "Password123"
+}
+```
+
+## Request with invalid inputs
+```json
+// request body with invalid login string that is too short
+{
+  "login": "use",
+  "password": "Password123"	
+}
+```
+
+## Response
+
+### Success: "`200 OK`"
+```json
+// response body
+{
+  "id": 60,
+  "email": "username444@email.com",
+  "username": "username444-email-com",
+  "createdAt": "2023-11-24T18:34:07.727Z",
+  "updatedAt": "2023-11-24T18:34:07.727Z"
+}
+```
+
+### Fail: "`401 Unauthorized`"
+This is the response for any http request with body that contains:
+- Login string that does not exist in the database, neither as username nor email; and / or
+- Password, which hash does not match with the hashed password stored in the database
+```json
+// response
+Unauthorized
+```
+
+### Fail: "`400 Bad Request`"
+<!-- textlint-disable -->
+- Http request body contains invalid input(s), that might be due to Front-end did not validate properly on User's inputs
+<!-- textlint-enable -->
+```json
+// response body
+{
+  "errors": [
+    {
+      "type": "field",
+      "value": "use",
+      "msg": "Email address must be minimum 6 and maximum 254 characters long",
+      "path": "login",
+      "location": "body"
+    },
+    {
+      "type": "field",
+      "value": "use",
+      "msg": "Email format must be valid, e.g: \"ab.cd@email.com\"",
+      "path": "login",
+      "location": "body"
+    },
+    {
+      "type": "field",
+      "value": "use",
+      "msg": "Username must be minimum 6 and maximum 254 characters long",
+      "path": "login",
+      "location": "body"
+    }
+  ]
+}
+```
+<!-- markdownlint-enable -->

--- a/docs/api.specifications/register.api.specifications.md
+++ b/docs/api.specifications/register.api.specifications.md
@@ -63,8 +63,8 @@
       "username444-email-com",
       "user",
       "$2b$10$smBwMyLWixaPrpTaCjG8O.FasIo2oD62o9dHF4zUz36HbnPWmiOri"
-		]
-	}
+    ]
+  }
 }
 ```
 
@@ -76,22 +76,22 @@ P.S. Front-end is correct as adjective, Front end is correct as a noun, Frontend
 ```json
 // response body
 {
-	"errors": [
-		{
-			"type": "field",
-			"value": "username444",
-			"msg": "Email format must be valid, e.g: \"ab.cd@email.com\"",
-			"path": "email",
-			"location": "body"
-		},
-		{
-			"type": "field",
-			"value": "username444",
-			"msg": "Email format must be valid, e.g: \"ab.cd@email.com\"",
-			"path": "email",
-			"location": "body"
-		}
-	]
+  "errors": [
+    {
+      "type": "field",
+      "value": "username444",
+      "msg": "Email format must be valid, e.g: \"ab.cd@email.com\"",
+      "path": "email",
+      "location": "body"
+    },
+    {
+      "type": "field",
+      "value": "username444",
+      "msg": "Email format must be valid, e.g: \"ab.cd@email.com\"",
+      "path": "email",
+      "location": "body"
+    }
+  ]
 }
 ```
 <!-- markdownlint-enable -->

--- a/src/app/controllers/account/account.controller.ts
+++ b/src/app/controllers/account/account.controller.ts
@@ -35,7 +35,7 @@ export const register = async (
 
   // auto-generate username initial value based on email address
   const regex = /[@.]/gi; // remove
-  const username = request.body.email.replace(regex, '-')
+  const username = request.body.email.replace(regex, '-');
   // auto-generate default initial value for role
   const role = 'user';
 

--- a/src/app/controllers/account/account.controller.ts
+++ b/src/app/controllers/account/account.controller.ts
@@ -33,10 +33,10 @@ export const register = async (
     return;
   }
 
-  // auto-create username initial value based on email address
+  // auto-generate username initial value based on email address
   const regex = /[@.]/gi; // remove
-  const username = request.body.email.replace(regex, '-'); // remove
-  // auto create default initial value for role
+  const username = request.body.email.replace(regex, '-')
+  // auto-generate default initial value for role
   const role = 'user';
 
   const query = {
@@ -117,40 +117,9 @@ export const evaluateLoginErrors = (
   next();
 };
 
-export const login = async (
-  request: Request,
-  response: Response,
-  next: NextFunction
-) => {
-  // if passport.authenticate has authenticate account by passing it as request.user, return ok response;
+export const login = async (request: Request, response: Response) => {
   if (request.user) {
     response.status(200).json(request.user);
-    return;
-  }
-
-  // else if login did not went through passport.authenticate
-  try {
-    const account = await db.one(
-      'SELECT * FROM "' + tableName + '" WHERE email = $1 OR username = $2;',
-      [request.body.login, request.body.login]
-    );
-
-    if (!account) {
-      next(errorHandler(404, 'Invalid login credentials'));
-    }
-
-    const validated = await bcrypt.compare(
-      request.body.password,
-      account.password
-    );
-
-    if (!validated) {
-      next(errorHandler(401, 'Invalid login credentials..'));
-    }
-
-    response.status(200).json(account);
-  } catch (error) {
-    next(error);
   }
 };
 

--- a/src/app/controllers/auth/passport.config.ts
+++ b/src/app/controllers/auth/passport.config.ts
@@ -20,21 +20,12 @@ export const initializePassport = (passport: PassportStatic) => {
     _password: string,
     done: Done
   ) => {
-    let account: AccountDTO;
 
     try {
-      // if login credential has '@', it is an email
-      if (login.includes('@')) {
-        account = await db.one(
-          'SELECT * FROM "' + tableName + '" WHERE EMAIL = $1;',
-          [login]
-        );
-      } else {
-        account = await db.one(
-          'SELECT * FROM "' + tableName + '" WHERE USERNAME = $1;',
-          [login]
-        );
-      }
+      const account = await db.one(
+        'SELECT * FROM "' + tableName + '" WHERE email = $1 OR username = $2;',
+        [login, login]
+      );
 
       if (!account) {
         return done(null, false, { message: 'account not found' });

--- a/src/app/controllers/auth/passport.config.ts
+++ b/src/app/controllers/auth/passport.config.ts
@@ -38,7 +38,7 @@ export const initializePassport = (passport: PassportStatic) => {
       return done(null, sanitized);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
-      // this block is here instead of in the try {} block as 'if (!account) {...}', because 
+      // this block is here instead of in the try {} block as 'if (!account) {...}', because
       // db returns error when there is nothing to return out of the query
       if (error.code === queryResultErrorCode.noData) {
         return done(null, false, { message: 'account not found' });

--- a/src/app/controllers/auth/passport.config.ts
+++ b/src/app/controllers/auth/passport.config.ts
@@ -3,7 +3,6 @@ import * as PassportLocal from 'passport-local';
 import bcrypt from 'bcrypt';
 
 import { db } from '../../../main';
-import { AccountDTO } from '../account/account.interface';
 import { tableName } from '../account/account.constant';
 
 const LocalStrategy = PassportLocal.Strategy;
@@ -20,7 +19,6 @@ export const initializePassport = (passport: PassportStatic) => {
     _password: string,
     done: Done
   ) => {
-
     try {
       const account = await db.one(
         'SELECT * FROM "' + tableName + '" WHERE email = $1 OR username = $2;',

--- a/src/app/controllers/constants.ts
+++ b/src/app/controllers/constants.ts
@@ -16,7 +16,8 @@ export const length = {
   },
 };
 
-export const valid = { // email validation handled by express-validator
+export const valid = {
+  // email validation handled by express-validator
   username: /^[a-z0-9][-a-z0-9_]*\$?$/, // username must be forced to lowercase, no one remembers casing & if we lowercased it, might cause confusion in login
   password: /(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}/,
 };

--- a/src/app/controllers/constants.ts
+++ b/src/app/controllers/constants.ts
@@ -5,46 +5,38 @@ export const length = {
   local.address@complete.domain */
   email: {
     min: 6, // i.e.: 'a@b.ca'
-    max: 255, // Longest email add is 320 and it is silly.
+    max: 254, // Longest email add is 320 and it is silly.
   },
   username: {
     min: 6, // google's enforced minimum length, although its use case (big users pool) very likely won't apply to app with small users pool
-    max: 255,
+    max: 254,
   },
   password: {
     min: 8, // common standard
   },
 };
 
-export const valid = {
-  username: /^[a-zA-Z0-9][-a-zA-Z0-9_]*\$?$/,
-  email:
-    // eslint-disable-next-line no-useless-escape
-    /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/,
+export const valid = { // email validation handled by express-validator
+  username: /^[a-z0-9][-a-z0-9_]*\$?$/, // username must be forced to lowercase, no one remembers casing & if we lowercased it, might cause confusion in login
   password: /(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}/,
 };
 
 export const errorMessages = {
   email: {
-    required: 'Required field',
-    minlength: 'Email format must be valid, e.g: "a@b.ca"',
-    maxLength: 'Email format must be valid, e.g: "not-this_long@email.com"',
+    exists: 'Email is required',
+    isLength: `Email address must be minimum ${length.username.min} and maximum ${length.username.max} characters long`,
     pattern: 'Email format must be valid, e.g: "ab.cd@email.com"',
   },
   username: {
-    required: 'Required field',
-    minlength: `Username must have a minimum of ${length.username.min} characters`,
-    maxLength: `Username must have a maximum of ${length.username.max} characters`,
+    exists: 'Username is required',
+    isLength: `Username must be minimum ${length.username.min} and maximum ${length.username.max} characters long`,
     pattern:
       'Username can only contain number, dash (-) underscore (-), lowercased letter, (NO CAPITAL letter), e.g: "user_name-2"',
   },
   password: {
-    required: 'Required field',
-    minlength: `Password must have a minimum of ${length.password.min} characters`,
+    exists: 'Password is required',
+    isLength: `Password must have a minimum of ${length.password.min} characters`,
     pattern:
       'Password must contain at least one number, one capital letter, and one lowercase letter, e.g.: paSsword123',
-  },
-  confirmPassword: {
-    required: 'Required field',
   },
 };

--- a/src/app/controllers/validators.ts
+++ b/src/app/controllers/validators.ts
@@ -4,50 +4,46 @@ import { length, valid, errorMessages } from './constants';
 
 const checkPassword = check('password')
   .exists({ checkFalsy: true })
-  .withMessage(`password: ${errorMessages.username.required}`)
+  .withMessage(errorMessages.password.exists)
   .isLength(length.password)
-  .withMessage(errorMessages.password.minlength)
+  .withMessage(errorMessages.password.isLength)
   .matches(valid.password)
   .withMessage(errorMessages.password.pattern);
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const checkUsername = check('username')
   .exists({ checkFalsy: true })
-  .withMessage(`username: ${errorMessages.username.required}`)
+  .withMessage(`username: ${errorMessages.username.exists}`)
   .isLength(length.username)
-  .withMessage(
-    `Email address must be minimum ${length.username.min} and maximum ${length.username.max} characters long`
-  )
+  .withMessage(errorMessages.username.isLength)
   .matches(valid.username)
   .withMessage(errorMessages.username.pattern);
 
-const login = [
-  check('login')
+export const loginValidators = [
+  check('login') // check for error as email
     .exists({ checkFalsy: true })
-    .withMessage(`email: ${errorMessages.email.required}`)
+    .withMessage(errorMessages.email.exists)
     .isLength(length.email)
-    .withMessage(
-      `login must be minimum ${length.email.min} and maximum ${length.email.max} characters long`
-    ),
+    .withMessage(errorMessages.email.isLength)
+    .isEmail()
+    .withMessage(errorMessages.email.pattern),
+  check('login') // check for error as username
+    .isLength(length.username)
+    .withMessage(errorMessages.username.isLength)
+    .matches(valid.username)
+    .withMessage(errorMessages.username.pattern),
   checkPassword,
 ];
 
-const register = [
+export const registerValidators = [
   check('email')
     .exists({ checkFalsy: true })
-    .withMessage(`email: ${errorMessages.email.required}`)
+    .withMessage(`email: ${errorMessages.email.exists}`)
     .isLength(length.email)
     .withMessage(
       `Email address must be minimum ${length.email.min} and maximum ${length.email.max} characters long`
     )
     .isEmail()
-    .withMessage(errorMessages.email.pattern)
-    .matches(valid.email)
     .withMessage(errorMessages.email.pattern),
   checkPassword,
 ];
-
-export const validators = {
-  login,
-  register,
-};

--- a/src/app/routes/account.route.ts
+++ b/src/app/routes/account.route.ts
@@ -4,15 +4,16 @@ import passport from 'passport';
 import {
   findAll,
   register,
+  evaluateLoginErrors,
   login,
   logout,
 } from '../controllers/account/account.controller';
-import { validators } from '../controllers/validators';
+import { registerValidators, loginValidators } from '../controllers/validators';
 
 export const account = express.Router();
 
 account.get('/', findAll);
-account.post('/register', validators.register, register);
+account.post('/register', registerValidators, register);
 
 const options = {
   successMessage: 'success',
@@ -20,7 +21,8 @@ const options = {
 };
 account.post(
   '/login',
-  validators.login,
+  loginValidators,
+  evaluateLoginErrors,
   passport.authenticate('local', options),
   login
 );

--- a/src/app/shared/utils/error.ts
+++ b/src/app/shared/utils/error.ts
@@ -66,8 +66,15 @@ export const handle404Error = (
 export const handleRemainingErrors = (
   error: _Error,
   _request: Request,
-  response: Response
+  response: Response,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _next: NextFunction
 ) => {
-  const message = error.message || 'Internal Server Error';
-  response.status(error.statusCode || 500).json({ message });
+  const statusCode = error.statusCode ? error.statusCode : 500;
+  const message = error.message ? error.message : 'Internal Server Error';
+  response.status(statusCode).json({ message });
+};
+
+export const queryResultErrorCode = {
+  noData: 0,
 };


### PR DESCRIPTION
# DONE

* When login, instead of doing an alternative querying based on whether login string is a username or email, decided to just do the OR on the psql query;
* Added additional logic before passing request into Passport.authenticate. So, if the login string is invalid both as a username nor as an email, server to just return the response 400 Bad Request as there are input errors, that might be because front-end did not do the proper validation;
* Refactor passport.authenticate fn, and login fn so that when database returns error because it could not find any document since there is no username or email in the database that matched the login in request body, the server can return a response to front-end;
* Added the api specs for /login